### PR TITLE
Update the FF def files for COF-H2 paper

### DIFF
--- a/2024-ACSAMI-H2-COF/ORGANIZED simulation files/4. H2 - GCMC/input files/forcefield/O-Mg-O_morse_newFF_single/force_field.def
+++ b/2024-ACSAMI-H2-COF/ORGANIZED simulation files/4. H2 - GCMC/input files/forcefield/O-Mg-O_morse_newFF_single/force_field.def
@@ -20,9 +20,9 @@ S       H_com   FEYNMAN_HIBBS_LENNARD_JONES     79.71   3.274   0.97
 Si      H_com   FEYNMAN_HIBBS_LENNARD_JONES     75.67   3.379   0.97
 V       H_com   FEYNMAN_HIBBS_LENNARD_JONES     17.19   2.879   0.98
 Zn      H_com   FEYNMAN_HIBBS_LENNARD_JONES     31.87   3.499   0.98
-H_h2	Mg_	morse	835.09000 	2.01400 	2.21400 
-H_h2	Sn_	morse	10.00000 	3.86200 	2.00000 
-H_h2	Te_	morse	10.02100 	1.01500 	4.98600 
+H_h2	Mg	morse	835.09000 	2.01400 	2.21400 
+H_h2	Sn	morse	10.00000 	3.86200 	2.00000 
+H_h2	Te	morse	10.02100 	1.01500 	4.98600 
 # mixing rules to overwrite
 0
 

--- a/2024-ACSAMI-H2-COF/ORGANIZED simulation files/4. H2 - GCMC/input files/forcefield/O-Mg-O_morse_newFF_single/force_field_mixing_rules.def
+++ b/2024-ACSAMI-H2-COF/ORGANIZED simulation files/4. H2 - GCMC/input files/forcefield/O-Mg-O_morse_newFF_single/force_field_mixing_rules.def
@@ -5,25 +5,25 @@ yes
 # number of defined interactions
 20
 # N/O/C/H/S/F/B/Al/Si/P/Cl/Ca/Zn/Fe from DREIDING; other metals from UFF; alkanes from modified TraPPE
-B_              lennard-jones          47.81    3.58
-Br_              lennard-jones         126.29   3.73
-C_              lennard-jones          47.86    3.47
-Cl_              lennard-jones         142.56   3.52
-Co_              lennard-jones         7.04     2.56
-Cu_              lennard-jones         2.52     3.11
-F_              lennard-jones          36.48    3.09
-H_              lennard-jones          7.65     2.85
-N_              lennard-jones          38.95    3.26
-Ni_              lennard-jones         7.55     2.52
-O_              lennard-jones          48.16    3.03
-S_              lennard-jones          173.11   3.59
-Si_              lennard-jones         156.00   3.80
-V_               lennard-jones         8.05     2.80
-Zn_              lennard-jones         27.68    4.04
+B              lennard-jones          47.81    3.58
+Br              lennard-jones         126.29   3.73
+C              lennard-jones          47.86    3.47
+Cl              lennard-jones         142.56   3.52
+Co              lennard-jones         7.04     2.56
+Cu              lennard-jones         2.52     3.11
+F              lennard-jones          36.48    3.09
+H              lennard-jones          7.65     2.85
+N              lennard-jones          38.95    3.26
+Ni              lennard-jones         7.55     2.52
+O              lennard-jones          48.16    3.03
+S              lennard-jones          173.11   3.59
+Si              lennard-jones         156.00   3.80
+V               lennard-jones         8.05     2.80
+Zn              lennard-jones         27.68    4.04
 H_h2                 lennard-jones                  0.0     0.0
 H_com                lennard-jones                  36.7   2.958
-Mg_            lennard-jones    55.8574   2.69141
-Sn_            lennard-jones    47.8562   3.47299
-Te_            lennard-jones    48.1581   3.03315
+Mg            lennard-jones    0.0   2.69141
+Sn            lennard-jones    0.0   3.47299
+Te            lennard-jones    0.0   3.03315
 # general mixing rule for Lennard-Jones
 Lorentz-Berthelot

--- a/2024-ACSAMI-H2-COF/ORGANIZED simulation files/4. H2 - GCMC/input files/forcefield/O-Mg-O_morse_newFF_single/pseudo_atoms.def
+++ b/2024-ACSAMI-H2-COF/ORGANIZED simulation files/4. H2 - GCMC/input files/forcefield/O-Mg-O_morse_newFF_single/pseudo_atoms.def
@@ -1,24 +1,24 @@
 #number of pseudo atoms
 20
 #type     print       as     chem     oxidation     mass          charge     polarization     B-factor     radii     connectivity     anisotropic anisotropic-type tinker-type
-B_     yes     B     B     0     10.811     0     0     1     1     0     0     relative     0
-Br_     yes     Br     Br     0     79.904     0     0     1     1     0     0     relative     0
-C_     yes     C     C     0     12.011     0     0     1     1     0     0     relative     0
-Cl_     yes     Cl     Cl     0     35.453     0     0     1     1     0     0     relative     0
-Co_     yes     Co     Co     0     58.933     0     0     1     1     0     0     relative     0
-Cu_     yes     Cu     Cu     0     63.546     0     0     1     1     0     0     relative     0
-F_     yes     F     F     0     18.998     0     0     1     1     0     0     relative     0
-H_     yes     H     H     0     1.008     0     0     1     1     0     0     relative     0
-N_     yes     N     N     0     14.007     0     0     1     1     0     0     relative     0
-Ni_     yes     Ni     Ni     0     58.693     0     0     1     1     0     0     relative     0
-O_     yes     O     O     0     15.999     0     0     1     1     0     0     relative     0
-S_     yes     S     S     0     32.066     0     0     1     1     0     0     relative     0
-Si_     yes     Si     Si     0     28.086     0     0     1     1     0     0     relative     0
-V_     yes     V     V     0     50.942     0     0     1     1     0     0     relative     0
-Zn_     yes     Zn     Zn     0     65.39     0     0     1     1     0     0     relative     0
+B     yes     B     B     0     10.811     0     0     1     1     0     0     relative     0
+Br     yes     Br     Br     0     79.904     0     0     1     1     0     0     relative     0
+C     yes     C     C     0     12.011     0     0     1     1     0     0     relative     0
+Cl     yes     Cl     Cl     0     35.453     0     0     1     1     0     0     relative     0
+Co     yes     Co     Co     0     58.933     0     0     1     1     0     0     relative     0
+Cu     yes     Cu     Cu     0     63.546     0     0     1     1     0     0     relative     0
+F     yes     F     F     0     18.998     0     0     1     1     0     0     relative     0
+H     yes     H     H     0     1.008     0     0     1     1     0     0     relative     0
+N     yes     N     N     0     14.007     0     0     1     1     0     0     relative     0
+Ni     yes     Ni     Ni     0     58.693     0     0     1     1     0     0     relative     0
+O     yes     O     O     0     15.999     0     0     1     1     0     0     relative     0
+S     yes     S     S     0     32.066     0     0     1     1     0     0     relative     0
+Si     yes     Si     Si     0     28.086     0     0     1     1     0     0     relative     0
+V     yes     V     V     0     50.942     0     0     1     1     0     0     relative     0
+Zn     yes     Zn     Zn     0     65.39     0     0     1     1     0     0     relative     0
 H_h2        yes     H     H     0      1.00794     0.468 0     1     1     0     0     relative     0
 H_com       no      H     H     0      0.0        -0.936 0     1     1     0     0     relative     0
-Mg_        yes     Mg    Mg    0           24.31       1.2500      0.0          1.0      1.0    0            0           relative           0
-Sn_        yes     Sn    C     0           12.0        0.0      0.0          1.0      1.0    0            0           relative           0
-Te_        yes     Te    O     0           15.9994     -0.6250      0.0          1.0      1.0    0            0           relative           0
+Mg        yes     Mg    Mg    0           24.31       1.2500      0.0          1.0      1.0    0            0           relative           0
+Sn        yes     Sn    C     0           12.0        0.0      0.0          1.0      1.0    0            0           relative           0
+Te        yes     Te    O     0           15.9994     -0.6250      0.0          1.0      1.0    0            0           relative           0
 

--- a/2024-ACSAMI-H2-COF/ORGANIZED simulation files/4. H2 - GCMC/input files/forcefield/O-Mg-O_morse_newFF_two/force_field_mixing_rules.def
+++ b/2024-ACSAMI-H2-COF/ORGANIZED simulation files/4. H2 - GCMC/input files/forcefield/O-Mg-O_morse_newFF_two/force_field_mixing_rules.def
@@ -22,8 +22,8 @@ V               lennard-jones         8.05     2.80
 Zn              lennard-jones         27.68    4.04
 H_h2                 lennard-jones                  0.0     0.0
 H_com                lennard-jones                  36.7   2.958
-Mg            lennard-jones    55.8574   2.69141
-Sn            lennard-jones    47.8562   3.47299
-Te            lennard-jones    48.1581   3.03315
+Mg            lennard-jones    0.0   2.69141
+Sn            lennard-jones    0.0   3.47299
+Te            lennard-jones    0.0   3.03315
 # general mixing rule for Lennard-Jones
 Lorentz-Berthelot


### PR DESCRIPTION
The self-interaction LJ parameters (epsilon) of three types of atoms in the functional group (Mg, C(Sn), O(Te)) are modified to 0.0, to ensure the H_com - Mg/Sn/Te interactions are zero.